### PR TITLE
Allow additional props and styles in Flexbox and FlexItem

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,5 +1,5 @@
 {
   "presets": [
-    "es2015", "react"
+    "es2015", "stage-0", "react"
   ]
 }

--- a/.gitignore
+++ b/.gitignore
@@ -4,5 +4,4 @@ logs
 node_modules
 tmp
 coverage
-dist
 npm-debug.log

--- a/dist/FlexItem.js
+++ b/dist/FlexItem.js
@@ -1,0 +1,110 @@
+'use strict';
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+
+var _extends = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; };
+
+var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
+
+var _react = require('react');
+
+var _react2 = _interopRequireDefault(_react);
+
+var _inlineStylePrefixer = require('inline-style-prefixer');
+
+var _inlineStylePrefixer2 = _interopRequireDefault(_inlineStylePrefixer);
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+function _objectWithoutProperties(obj, keys) { var target = {}; for (var i in obj) { if (keys.indexOf(i) >= 0) continue; if (!Object.prototype.hasOwnProperty.call(obj, i)) continue; target[i] = obj[i]; } return target; }
+
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
+
+function _possibleConstructorReturn(self, call) { if (!self) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return call && (typeof call === "object" || typeof call === "function") ? call : self; }
+
+function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function, not " + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
+
+var prefixer = new _inlineStylePrefixer2.default();
+
+var FlexItem = function (_React$Component) {
+  _inherits(FlexItem, _React$Component);
+
+  function FlexItem() {
+    _classCallCheck(this, FlexItem);
+
+    return _possibleConstructorReturn(this, Object.getPrototypeOf(FlexItem).apply(this, arguments));
+  }
+
+  _createClass(FlexItem, [{
+    key: 'styles',
+    value: function styles() {
+      var _props = this.props;
+      var alignSelf = _props.alignSelf;
+      var flex = _props.flex;
+      var flexBasis = _props.flexBasis;
+      var flexGrow = _props.flexGrow;
+      var flexShrink = _props.flexShrink;
+      var height = _props.height;
+      var margin = _props.margin;
+      var maxHeight = _props.maxHeight;
+      var minHeight = _props.minHeight;
+      var maxWidth = _props.maxWidth;
+      var minWidth = _props.minWidth;
+      var order = _props.order;
+      var padding = _props.padding;
+      var width = _props.width;
+
+      var props = _objectWithoutProperties(_props, ['alignSelf', 'flex', 'flexBasis', 'flexGrow', 'flexShrink', 'height', 'margin', 'maxHeight', 'minHeight', 'maxWidth', 'minWidth', 'order', 'padding', 'width']);
+
+      return prefixer.prefix({
+        alignSelf: alignSelf,
+        flex: flex,
+        flexBasis: flexBasis,
+        flexGrow: flexGrow,
+        flexShrink: flexShrink,
+        height: height,
+        margin: margin,
+        maxHeight: maxHeight,
+        minHeight: minHeight,
+        maxWidth: maxWidth,
+        minWidth: minWidth,
+        order: order,
+        padding: padding,
+        width: width
+      });
+    }
+  }, {
+    key: 'render',
+    value: function render() {
+      return _react2.default.createElement(
+        'div',
+        _extends({}, props, { style: this.styles() }),
+        this.props.children
+      );
+    }
+  }]);
+
+  return FlexItem;
+}(_react2.default.Component);
+
+FlexItem.propTypes = {
+  alignSelf: _react.PropTypes.oneOf(['flex-start', 'flex-end', 'center', 'baseline', 'stretch']),
+  children: _react2.default.PropTypes.node,
+  flex: _react.PropTypes.string,
+  flexBasis: _react.PropTypes.string,
+  flexGrow: _react.PropTypes.number,
+  flexShrink: _react.PropTypes.number,
+  height: _react.PropTypes.string,
+  margin: _react.PropTypes.string,
+  maxHeight: _react.PropTypes.string,
+  minHeight: _react.PropTypes.string,
+  maxWidth: _react.PropTypes.string,
+  minWidth: _react.PropTypes.string,
+  order: _react.PropTypes.number,
+  padding: _react.PropTypes.string,
+  width: _react.PropTypes.string
+};
+
+exports.default = FlexItem;

--- a/dist/FlexItem.js
+++ b/dist/FlexItem.js
@@ -6,8 +6,6 @@ Object.defineProperty(exports, "__esModule", {
 
 var _extends = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; };
 
-var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
-
 var _react = require('react');
 
 var _react2 = _interopRequireDefault(_react);
@@ -20,74 +18,50 @@ function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { de
 
 function _objectWithoutProperties(obj, keys) { var target = {}; for (var i in obj) { if (keys.indexOf(i) >= 0) continue; if (!Object.prototype.hasOwnProperty.call(obj, i)) continue; target[i] = obj[i]; } return target; }
 
-function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
-
-function _possibleConstructorReturn(self, call) { if (!self) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return call && (typeof call === "object" || typeof call === "function") ? call : self; }
-
-function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function, not " + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
-
 var prefixer = new _inlineStylePrefixer2.default();
 
-var FlexItem = function (_React$Component) {
-  _inherits(FlexItem, _React$Component);
+var FlexItem = function FlexItem(props) {
+  var style = props.style;
+  var alignSelf = props.alignSelf;
+  var flex = props.flex;
+  var flexBasis = props.flexBasis;
+  var flexGrow = props.flexGrow;
+  var flexShrink = props.flexShrink;
+  var height = props.height;
+  var margin = props.margin;
+  var maxHeight = props.maxHeight;
+  var minHeight = props.minHeight;
+  var maxWidth = props.maxWidth;
+  var minWidth = props.minWidth;
+  var order = props.order;
+  var padding = props.padding;
+  var width = props.width;
 
-  function FlexItem() {
-    _classCallCheck(this, FlexItem);
+  var other = _objectWithoutProperties(props, ['style', 'alignSelf', 'flex', 'flexBasis', 'flexGrow', 'flexShrink', 'height', 'margin', 'maxHeight', 'minHeight', 'maxWidth', 'minWidth', 'order', 'padding', 'width']);
 
-    return _possibleConstructorReturn(this, Object.getPrototypeOf(FlexItem).apply(this, arguments));
-  }
+  var styles = prefixer.prefix(_extends({}, style, {
+    alignSelf: alignSelf,
+    flex: flex,
+    flexBasis: flexBasis,
+    flexGrow: flexGrow,
+    flexShrink: flexShrink,
+    height: height,
+    margin: margin,
+    maxHeight: maxHeight,
+    minHeight: minHeight,
+    maxWidth: maxWidth,
+    minWidth: minWidth,
+    order: order,
+    padding: padding,
+    width: width
+  }));
 
-  _createClass(FlexItem, [{
-    key: 'styles',
-    value: function styles() {
-      var _props = this.props;
-      var alignSelf = _props.alignSelf;
-      var flex = _props.flex;
-      var flexBasis = _props.flexBasis;
-      var flexGrow = _props.flexGrow;
-      var flexShrink = _props.flexShrink;
-      var height = _props.height;
-      var margin = _props.margin;
-      var maxHeight = _props.maxHeight;
-      var minHeight = _props.minHeight;
-      var maxWidth = _props.maxWidth;
-      var minWidth = _props.minWidth;
-      var order = _props.order;
-      var padding = _props.padding;
-      var width = _props.width;
-
-      var props = _objectWithoutProperties(_props, ['alignSelf', 'flex', 'flexBasis', 'flexGrow', 'flexShrink', 'height', 'margin', 'maxHeight', 'minHeight', 'maxWidth', 'minWidth', 'order', 'padding', 'width']);
-
-      return prefixer.prefix({
-        alignSelf: alignSelf,
-        flex: flex,
-        flexBasis: flexBasis,
-        flexGrow: flexGrow,
-        flexShrink: flexShrink,
-        height: height,
-        margin: margin,
-        maxHeight: maxHeight,
-        minHeight: minHeight,
-        maxWidth: maxWidth,
-        minWidth: minWidth,
-        order: order,
-        padding: padding,
-        width: width
-      });
-    }
-  }, {
-    key: 'render',
-    value: function render() {
-      return _react2.default.createElement(
-        'div',
-        _extends({}, props, { style: this.styles() }),
-        this.props.children
-      );
-    }
-  }]);
-
-  return FlexItem;
-}(_react2.default.Component);
+  return _react2.default.createElement(
+    'div',
+    _extends({}, other, { style: styles }),
+    undefined.props.children
+  );
+};
 
 FlexItem.propTypes = {
   alignSelf: _react.PropTypes.oneOf(['flex-start', 'flex-end', 'center', 'baseline', 'stretch']),
@@ -104,6 +78,7 @@ FlexItem.propTypes = {
   minWidth: _react.PropTypes.string,
   order: _react.PropTypes.number,
   padding: _react.PropTypes.string,
+  style: _react.PropTypes.object,
   width: _react.PropTypes.string
 };
 

--- a/dist/FlexItem.js
+++ b/dist/FlexItem.js
@@ -59,7 +59,7 @@ var FlexItem = function FlexItem(props) {
   return _react2.default.createElement(
     'div',
     _extends({}, other, { style: styles }),
-    undefined.props.children
+    props.children
   );
 };
 

--- a/dist/Flexbox.js
+++ b/dist/Flexbox.js
@@ -1,0 +1,112 @@
+'use strict';
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+
+var _extends = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; };
+
+var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
+
+var _react = require('react');
+
+var _react2 = _interopRequireDefault(_react);
+
+var _inlineStylePrefixer = require('inline-style-prefixer');
+
+var _inlineStylePrefixer2 = _interopRequireDefault(_inlineStylePrefixer);
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+function _objectWithoutProperties(obj, keys) { var target = {}; for (var i in obj) { if (keys.indexOf(i) >= 0) continue; if (!Object.prototype.hasOwnProperty.call(obj, i)) continue; target[i] = obj[i]; } return target; }
+
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
+
+function _possibleConstructorReturn(self, call) { if (!self) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return call && (typeof call === "object" || typeof call === "function") ? call : self; }
+
+function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function, not " + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
+
+var prefixer = new _inlineStylePrefixer2.default();
+
+var Flexbox = function (_React$Component) {
+  _inherits(Flexbox, _React$Component);
+
+  function Flexbox() {
+    _classCallCheck(this, Flexbox);
+
+    return _possibleConstructorReturn(this, Object.getPrototypeOf(Flexbox).apply(this, arguments));
+  }
+
+  _createClass(Flexbox, [{
+    key: 'styles',
+    value: function styles() {
+      var _props = this.props;
+      var alignContent = _props.alignContent;
+      var alignItems = _props.alignItems;
+      var flexDirection = _props.flexDirection;
+      var flexWrap = _props.flexWrap;
+      var height = _props.height;
+      var justifyContent = _props.justifyContent;
+      var margin = _props.margin;
+      var maxHeight = _props.maxHeight;
+      var minHeight = _props.minHeight;
+      var maxWidth = _props.maxWidth;
+      var minWidth = _props.minWidth;
+      var padding = _props.padding;
+      var width = _props.width;
+      var inline = _props.inline;
+
+      var props = _objectWithoutProperties(_props, ['alignContent', 'alignItems', 'flexDirection', 'flexWrap', 'height', 'justifyContent', 'margin', 'maxHeight', 'minHeight', 'maxWidth', 'minWidth', 'padding', 'width', 'inline']);
+
+      var display = this.props.inline ? 'inline-flex' : 'flex';
+
+      return prefixer.prefix({
+        alignContent: alignContent,
+        alignItems: alignItems,
+        display: display,
+        flexDirection: flexDirection,
+        flexWrap: flexWrap,
+        height: height,
+        justifyContent: justifyContent,
+        margin: margin,
+        maxHeight: maxHeight,
+        minHeight: minHeight,
+        maxWidth: maxWidth,
+        minWidth: minWidth,
+        padding: padding,
+        width: width
+      });
+    }
+  }, {
+    key: 'render',
+    value: function render() {
+      return _react2.default.createElement(
+        'div',
+        _extends({}, props, { style: this.styles() }),
+        this.props.children
+      );
+    }
+  }]);
+
+  return Flexbox;
+}(_react2.default.Component);
+
+Flexbox.propTypes = {
+  alignContent: _react.PropTypes.oneOf(['flex-start', 'flex-end', 'center', 'space-between', 'space-around', 'stretch']),
+  alignItems: _react.PropTypes.oneOf(['flex-start', 'flex-end', 'center', 'baseline', 'stretch']),
+  children: _react2.default.PropTypes.node,
+  flexDirection: _react.PropTypes.oneOf(['row', 'row-reverse', 'column', 'column-reverse']),
+  flexWrap: _react.PropTypes.oneOf(['nowrap', 'wrap', 'wrap-reverse']),
+  height: _react.PropTypes.string,
+  inline: _react.PropTypes.bool,
+  justifyContent: _react.PropTypes.oneOf(['flex-start', 'flex-end', 'center', 'space-between', 'space-around']),
+  margin: _react.PropTypes.string,
+  maxHeight: _react.PropTypes.string,
+  minHeight: _react.PropTypes.string,
+  maxWidth: _react.PropTypes.string,
+  minWidth: _react.PropTypes.string,
+  padding: _react.PropTypes.string,
+  width: _react.PropTypes.string
+};
+
+exports.default = Flexbox;

--- a/dist/Flexbox.js
+++ b/dist/Flexbox.js
@@ -6,8 +6,6 @@ Object.defineProperty(exports, "__esModule", {
 
 var _extends = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; };
 
-var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
-
 var _react = require('react');
 
 var _react2 = _interopRequireDefault(_react);
@@ -20,76 +18,52 @@ function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { de
 
 function _objectWithoutProperties(obj, keys) { var target = {}; for (var i in obj) { if (keys.indexOf(i) >= 0) continue; if (!Object.prototype.hasOwnProperty.call(obj, i)) continue; target[i] = obj[i]; } return target; }
 
-function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
-
-function _possibleConstructorReturn(self, call) { if (!self) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return call && (typeof call === "object" || typeof call === "function") ? call : self; }
-
-function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function, not " + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
-
 var prefixer = new _inlineStylePrefixer2.default();
 
-var Flexbox = function (_React$Component) {
-  _inherits(Flexbox, _React$Component);
+var Flexbox = function Flexbox(props) {
+  var style = props.style;
+  var alignContent = props.alignContent;
+  var alignItems = props.alignItems;
+  var flexDirection = props.flexDirection;
+  var flexWrap = props.flexWrap;
+  var height = props.height;
+  var justifyContent = props.justifyContent;
+  var margin = props.margin;
+  var maxHeight = props.maxHeight;
+  var minHeight = props.minHeight;
+  var maxWidth = props.maxWidth;
+  var minWidth = props.minWidth;
+  var padding = props.padding;
+  var width = props.width;
+  var inline = props.inline;
 
-  function Flexbox() {
-    _classCallCheck(this, Flexbox);
+  var other = _objectWithoutProperties(props, ['style', 'alignContent', 'alignItems', 'flexDirection', 'flexWrap', 'height', 'justifyContent', 'margin', 'maxHeight', 'minHeight', 'maxWidth', 'minWidth', 'padding', 'width', 'inline']);
 
-    return _possibleConstructorReturn(this, Object.getPrototypeOf(Flexbox).apply(this, arguments));
-  }
+  var display = inline ? 'inline-flex' : 'flex';
 
-  _createClass(Flexbox, [{
-    key: 'styles',
-    value: function styles() {
-      var _props = this.props;
-      var alignContent = _props.alignContent;
-      var alignItems = _props.alignItems;
-      var flexDirection = _props.flexDirection;
-      var flexWrap = _props.flexWrap;
-      var height = _props.height;
-      var justifyContent = _props.justifyContent;
-      var margin = _props.margin;
-      var maxHeight = _props.maxHeight;
-      var minHeight = _props.minHeight;
-      var maxWidth = _props.maxWidth;
-      var minWidth = _props.minWidth;
-      var padding = _props.padding;
-      var width = _props.width;
-      var inline = _props.inline;
+  var styles = prefixer.prefix(_extends({}, style, {
+    alignContent: alignContent,
+    alignItems: alignItems,
+    display: display,
+    flexDirection: flexDirection,
+    flexWrap: flexWrap,
+    height: height,
+    justifyContent: justifyContent,
+    margin: margin,
+    maxHeight: maxHeight,
+    minHeight: minHeight,
+    maxWidth: maxWidth,
+    minWidth: minWidth,
+    padding: padding,
+    width: width
+  }));
 
-      var props = _objectWithoutProperties(_props, ['alignContent', 'alignItems', 'flexDirection', 'flexWrap', 'height', 'justifyContent', 'margin', 'maxHeight', 'minHeight', 'maxWidth', 'minWidth', 'padding', 'width', 'inline']);
-
-      var display = this.props.inline ? 'inline-flex' : 'flex';
-
-      return prefixer.prefix({
-        alignContent: alignContent,
-        alignItems: alignItems,
-        display: display,
-        flexDirection: flexDirection,
-        flexWrap: flexWrap,
-        height: height,
-        justifyContent: justifyContent,
-        margin: margin,
-        maxHeight: maxHeight,
-        minHeight: minHeight,
-        maxWidth: maxWidth,
-        minWidth: minWidth,
-        padding: padding,
-        width: width
-      });
-    }
-  }, {
-    key: 'render',
-    value: function render() {
-      return _react2.default.createElement(
-        'div',
-        _extends({}, props, { style: this.styles() }),
-        this.props.children
-      );
-    }
-  }]);
-
-  return Flexbox;
-}(_react2.default.Component);
+  return _react2.default.createElement(
+    'div',
+    _extends({}, other, { style: styles }),
+    undefined.props.children
+  );
+};
 
 Flexbox.propTypes = {
   alignContent: _react.PropTypes.oneOf(['flex-start', 'flex-end', 'center', 'space-between', 'space-around', 'stretch']),
@@ -106,6 +80,7 @@ Flexbox.propTypes = {
   maxWidth: _react.PropTypes.string,
   minWidth: _react.PropTypes.string,
   padding: _react.PropTypes.string,
+  style: _react.PropTypes.object,
   width: _react.PropTypes.string
 };
 

--- a/dist/Flexbox.js
+++ b/dist/Flexbox.js
@@ -61,7 +61,7 @@ var Flexbox = function Flexbox(props) {
   return _react2.default.createElement(
     'div',
     _extends({}, other, { style: styles }),
-    undefined.props.children
+    props.children
   );
 };
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -1,0 +1,19 @@
+'use strict';
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+exports.FlexItem = exports.Flexbox = undefined;
+
+var _Flexbox = require('./Flexbox');
+
+var _Flexbox2 = _interopRequireDefault(_Flexbox);
+
+var _FlexItem = require('./FlexItem');
+
+var _FlexItem2 = _interopRequireDefault(_FlexItem);
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+exports.Flexbox = _Flexbox2.default;
+exports.FlexItem = _FlexItem2.default;

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "babel-eslint": "*",
     "babel-preset-es2015": "*",
     "babel-preset-react": "*",
-    "babel-preset-stage-0": "^6.5.0",
+    "babel-preset-stage-0": "*",
     "coveralls": "*",
     "dependency-check": "*",
     "doctoc": "*",

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "babel-eslint": "*",
     "babel-preset-es2015": "*",
     "babel-preset-react": "*",
+    "babel-preset-stage-0": "^6.5.0",
     "coveralls": "*",
     "dependency-check": "*",
     "doctoc": "*",

--- a/src/FlexItem.jsx
+++ b/src/FlexItem.jsx
@@ -5,26 +5,44 @@ const prefixer = new Prefixer();
 
 class FlexItem extends React.Component {
   styles() {
+    const {
+      alignSelf,
+      flex,
+      flexBasis,
+      flexGrow,
+      flexShrink,
+      height,
+      margin,
+      maxHeight,
+      minHeight,
+      maxWidth,
+      minWidth,
+      order,
+      padding,
+      width,
+      ...props
+    } = this.props;
+
     return prefixer.prefix({
-      alignSelf: this.props.alignSelf,
-      flex: this.props.flex,
-      flexBasis: this.props.flexBasis,
-      flexGrow: this.props.flexGrow,
-      flexShrink: this.props.flexShrink,
-      height: this.props.height,
-      margin: this.props.margin,
-      maxHeight: this.props.maxHeight,
-      minHeight: this.props.minHeight,
-      maxWidth: this.props.maxWidth,
-      minWidth: this.props.minWidth,
-      order: this.props.order,
-      padding: this.props.padding,
-      width: this.props.width,
+      alignSelf,
+      flex,
+      flexBasis,
+      flexGrow,
+      flexShrink,
+      height,
+      margin,
+      maxHeight,
+      minHeight,
+      maxWidth,
+      minWidth,
+      order,
+      padding,
+      width
     });
   }
   render() {
     return (
-      <div style={this.styles()} className={this.props.className}>
+      <div {...props} style={this.styles()}>
         {this.props.children}
       </div>
     );
@@ -40,7 +58,6 @@ FlexItem.propTypes = {
     'stretch',
   ]),
   children: React.PropTypes.node,
-  className: React.PropTypes.string,
   flex: PropTypes.string,
   flexBasis: PropTypes.string,
   flexGrow: PropTypes.number,

--- a/src/FlexItem.jsx
+++ b/src/FlexItem.jsx
@@ -43,7 +43,7 @@ const FlexItem = (props) => {
 
   return (
     <div {...other} style={styles}>
-      {this.props.children}
+      {props.children}
     </div>
   );
 };

--- a/src/FlexItem.jsx
+++ b/src/FlexItem.jsx
@@ -3,51 +3,50 @@ import Prefixer from 'inline-style-prefixer';
 
 const prefixer = new Prefixer();
 
-class FlexItem extends React.Component {
-  styles() {
-    const {
-      alignSelf,
-      flex,
-      flexBasis,
-      flexGrow,
-      flexShrink,
-      height,
-      margin,
-      maxHeight,
-      minHeight,
-      maxWidth,
-      minWidth,
-      order,
-      padding,
-      width,
-      ...props
-    } = this.props;
+const FlexItem = (props) => {
+  const {
+    style,
+    alignSelf,
+    flex,
+    flexBasis,
+    flexGrow,
+    flexShrink,
+    height,
+    margin,
+    maxHeight,
+    minHeight,
+    maxWidth,
+    minWidth,
+    order,
+    padding,
+    width,
+    ...other,
+  } = props;
 
-    return prefixer.prefix({
-      alignSelf,
-      flex,
-      flexBasis,
-      flexGrow,
-      flexShrink,
-      height,
-      margin,
-      maxHeight,
-      minHeight,
-      maxWidth,
-      minWidth,
-      order,
-      padding,
-      width
-    });
-  }
-  render() {
-    return (
-      <div {...props} style={this.styles()}>
-        {this.props.children}
-      </div>
-    );
-  }
-}
+  const styles = prefixer.prefix({
+    ...style,
+    alignSelf,
+    flex,
+    flexBasis,
+    flexGrow,
+    flexShrink,
+    height,
+    margin,
+    maxHeight,
+    minHeight,
+    maxWidth,
+    minWidth,
+    order,
+    padding,
+    width,
+  });
+
+  return (
+    <div {...other} style={styles}>
+      {this.props.children}
+    </div>
+  );
+};
 
 FlexItem.propTypes = {
   alignSelf: PropTypes.oneOf([
@@ -70,6 +69,7 @@ FlexItem.propTypes = {
   minWidth: PropTypes.string,
   order: PropTypes.number,
   padding: PropTypes.string,
+  style: PropTypes.object,
   width: PropTypes.string,
 };
 

--- a/src/Flexbox.jsx
+++ b/src/Flexbox.jsx
@@ -5,26 +5,46 @@ const prefixer = new Prefixer();
 
 class Flexbox extends React.Component {
   styles() {
+    const {
+      alignContent,
+      alignItems,
+      flexDirection,
+      flexWrap,
+      height,
+      justifyContent,
+      margin,
+      maxHeight,
+      minHeight,
+      maxWidth,
+      minWidth,
+      padding,
+      width,
+      inline,
+      ...props
+    } = this.props;
+
+    const display = this.props.inline ? 'inline-flex' : 'flex';
+
     return prefixer.prefix({
-      alignContent: this.props.alignContent,
-      alignItems: this.props.alignItems,
-      display: this.props.inline ? 'inline-flex' : 'flex',
-      flexDirection: this.props.flexDirection,
-      flexWrap: this.props.flexWrap,
-      height: this.props.height,
-      justifyContent: this.props.justifyContent,
-      margin: this.props.margin,
-      maxHeight: this.props.maxHeight,
-      minHeight: this.props.minHeight,
-      maxWidth: this.props.maxWidth,
-      minWidth: this.props.minWidth,
-      padding: this.props.padding,
-      width: this.props.width,
+      alignContent,
+      alignItems,
+      display,
+      flexDirection,
+      flexWrap,
+      height,
+      justifyContent,
+      margin,
+      maxHeight,
+      minHeight,
+      maxWidth,
+      minWidth,
+      padding,
+      width,
     });
   }
   render() {
     return (
-      <div style={this.styles()} className={this.props.className}>
+      <div {...props} style={this.styles()}>
         {this.props.children}
       </div>
     );
@@ -48,7 +68,6 @@ Flexbox.propTypes = {
     'stretch',
   ]),
   children: React.PropTypes.node,
-  className: React.PropTypes.string,
   flexDirection: PropTypes.oneOf([
     'row',
     'row-reverse',

--- a/src/Flexbox.jsx
+++ b/src/Flexbox.jsx
@@ -45,7 +45,7 @@ const Flexbox = (props) => {
 
   return (
     <div {...other} style={styles}>
-      {this.props.children}
+      {props.children}
     </div>
   );
 };

--- a/src/Flexbox.jsx
+++ b/src/Flexbox.jsx
@@ -3,53 +3,52 @@ import Prefixer from 'inline-style-prefixer';
 
 const prefixer = new Prefixer();
 
-class Flexbox extends React.Component {
-  styles() {
-    const {
-      alignContent,
-      alignItems,
-      flexDirection,
-      flexWrap,
-      height,
-      justifyContent,
-      margin,
-      maxHeight,
-      minHeight,
-      maxWidth,
-      minWidth,
-      padding,
-      width,
-      inline,
-      ...props
-    } = this.props;
+const Flexbox = (props) => {
+  const {
+    style,
+    alignContent,
+    alignItems,
+    flexDirection,
+    flexWrap,
+    height,
+    justifyContent,
+    margin,
+    maxHeight,
+    minHeight,
+    maxWidth,
+    minWidth,
+    padding,
+    width,
+    inline,
+    ...other,
+  } = props;
 
-    const display = this.props.inline ? 'inline-flex' : 'flex';
+  const display = inline ? 'inline-flex' : 'flex';
 
-    return prefixer.prefix({
-      alignContent,
-      alignItems,
-      display,
-      flexDirection,
-      flexWrap,
-      height,
-      justifyContent,
-      margin,
-      maxHeight,
-      minHeight,
-      maxWidth,
-      minWidth,
-      padding,
-      width,
-    });
-  }
-  render() {
-    return (
-      <div {...props} style={this.styles()}>
-        {this.props.children}
-      </div>
-    );
-  }
-}
+  const styles = prefixer.prefix({
+    ...style,
+    alignContent,
+    alignItems,
+    display,
+    flexDirection,
+    flexWrap,
+    height,
+    justifyContent,
+    margin,
+    maxHeight,
+    minHeight,
+    maxWidth,
+    minWidth,
+    padding,
+    width,
+  });
+
+  return (
+    <div {...other} style={styles}>
+      {this.props.children}
+    </div>
+  );
+};
 
 Flexbox.propTypes = {
   alignContent: PropTypes.oneOf([
@@ -94,6 +93,7 @@ Flexbox.propTypes = {
   maxWidth: PropTypes.string,
   minWidth: PropTypes.string,
   padding: PropTypes.string,
+  style: PropTypes.object,
   width: PropTypes.string,
 };
 


### PR DESCRIPTION
Fixes #1.

Props that are not part of the flexbox styling are captured and applied within the resulting div. This allows you to do things like:

```
<Flexbox flexDirection="row" onClick={this.handleClick} >
```

User styling passed to `<Flexbox>` and `<FlexItem>` are added into the resulting inline style for the div.

```
const myStyle = {
    background: "#EEE"
};
...
<Flexbox style={myStyle} flexDirection="row" >
```

Additionally:
- Added the ./dist directory into git so this can be used directly from github
- Components are now stateless functions
