### PR TITLE
Add support for semantic sectioning elements

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
     <img src="https://travis-ci.org/nachoaIvarez/flexbox-react.svg?branch=master"
          alt="Build Status">
   </a>
-  
+
   <a href="https://npmjs.org/package/flexbox-react">
     <img src="https://img.shields.io/npm/v/flexbox-react.svg?style=flat-square"
          alt="NPM Version">
@@ -83,6 +83,24 @@ import Flexbox from 'flexbox-react';
 *Sticky footer!*
 
 As you can see, there's some extra props as _layout_&hairsp;ing helpers. Those are `height`, `minHeight`, `maxHeight`, `width`, `minWidth`, `maxWidth`, `padding`, `paddingTop`, `paddingRight`, `paddingBottom`, `paddingLeft`, `margin`, `marginTop`, `marginRight`, `marginBottom`, and `marginLeft`. The idea of `flexbox-react` is to be a complete solution to build layouts. Since, well, flexbox it is a complete solution to build layouts. It's all about the sugar. Feel free to create an issue or submit a PR if you think there's room for improvement here!
+
+### Semantic HTML tags
+
+If you need to use a tag other than `<div>` for the layout, like `<header>` or `<section>`, you can pass an extra `element` prop to the `<Flexbox />` component:
+
+```html
+Flexbox element="header" height="80px">
+  ...
+</Flexbox>
+```
+
+which will render to this:
+
+```html
+<header style="display: flex; height: 80px;">
+  ...
+</header>
+```
 
 ## Props
 Take a look at

--- a/dist/Flexbox.js
+++ b/dist/Flexbox.js
@@ -24,6 +24,8 @@ var Flexbox = function Flexbox(props) {
   var alignContent = props.alignContent;
   var alignItems = props.alignItems;
   var alignSelf = props.alignSelf;
+  var children = props.children;
+  var element = props.element;
   var flex = props.flex;
   var flexBasis = props.flexBasis;
   var flexDirection = props.flexDirection;
@@ -51,7 +53,7 @@ var Flexbox = function Flexbox(props) {
   var style = props.style;
   var width = props.width;
 
-  var other = _objectWithoutProperties(props, ['alignContent', 'alignItems', 'alignSelf', 'flex', 'flexBasis', 'flexDirection', 'flexGrow', 'flexShrink', 'flexWrap', 'height', 'inline', 'justifyContent', 'margin', 'marginBottom', 'marginLeft', 'marginRight', 'marginTop', 'maxHeight', 'maxWidth', 'minHeight', 'minWidth', 'order', 'padding', 'paddingBottom', 'paddingLeft', 'paddingRight', 'paddingTop', 'style', 'width']);
+  var other = _objectWithoutProperties(props, ['alignContent', 'alignItems', 'alignSelf', 'children', 'element', 'flex', 'flexBasis', 'flexDirection', 'flexGrow', 'flexShrink', 'flexWrap', 'height', 'inline', 'justifyContent', 'margin', 'marginBottom', 'marginLeft', 'marginRight', 'marginTop', 'maxHeight', 'maxWidth', 'minHeight', 'minWidth', 'order', 'padding', 'paddingBottom', 'paddingLeft', 'paddingRight', 'paddingTop', 'style', 'width']);
 
   var display = inline ? 'inline-flex' : 'flex';
 
@@ -86,17 +88,16 @@ var Flexbox = function Flexbox(props) {
     width: width
   }, style));
 
-  return _react2.default.createElement(
-    'div',
-    _extends({}, other, { style: styles }),
-    props.children
-  );
+  return _react2.default.createElement(element, _extends({}, other, {
+    style: styles
+  }), children);
 };
 
 Flexbox.propTypes = {
   alignContent: _react.PropTypes.oneOf(['flex-start', 'flex-end', 'center', 'space-between', 'space-around', 'stretch']),
   alignItems: _react.PropTypes.oneOf(['flex-start', 'flex-end', 'center', 'baseline', 'stretch']),
   children: _react2.default.PropTypes.node,
+  element: _react.PropTypes.oneOf(['article', 'aside', 'div', 'footer', 'header', 'nav', 'section']),
   flex: _react.PropTypes.string,
   flexBasis: _react.PropTypes.string,
   flexDirection: _react.PropTypes.oneOf(['row', 'row-reverse', 'column', 'column-reverse']),
@@ -124,6 +125,10 @@ Flexbox.propTypes = {
   paddingTop: _react.PropTypes.string,
   style: _react.PropTypes.object,
   width: _react.PropTypes.string
+};
+
+Flexbox.defaultProps = {
+  element: 'div'
 };
 
 exports.default = Flexbox;

--- a/src/Flexbox.jsx
+++ b/src/Flexbox.jsx
@@ -8,6 +8,8 @@ const Flexbox = (props) => {
     alignContent,
     alignItems,
     alignSelf,
+    children,
+    element,
     flex,
     flexBasis,
     flexDirection,
@@ -71,11 +73,10 @@ const Flexbox = (props) => {
     ...style,
   });
 
-  return (
-    <div {...other} style={styles}>
-      {props.children}
-    </div>
-  );
+  return React.createElement(element, {
+    ...other,
+    style: styles,
+  }, children);
 };
 
 Flexbox.propTypes = {
@@ -95,6 +96,15 @@ Flexbox.propTypes = {
     'stretch',
   ]),
   children: React.PropTypes.node,
+  element: PropTypes.oneOf([
+    'article',
+    'aside',
+    'div',
+    'footer',
+    'header',
+    'nav',
+    'section',
+  ]),
   flex: PropTypes.string,
   flexBasis: PropTypes.string,
   flexDirection: PropTypes.oneOf([
@@ -143,6 +153,10 @@ Flexbox.propTypes = {
   paddingTop: PropTypes.string,
   style: PropTypes.object,
   width: PropTypes.string,
+};
+
+Flexbox.defaultProps = {
+  element: 'div',
 };
 
 export default Flexbox;


### PR DESCRIPTION
This fixes #6.
- [x] Add `element` prop to `<Flexbox />` API, which needs to be one of: `'article'`, `'aside'`, `'div'`, `'footer'`, `'header'`, `'nav'` or `'section'`.
- [x] Default `element` prop to `'div'`.
- [x] Update README.md.
