### PR TITLE
Replace inline with display

### DIFF
--- a/dist/Flexbox.js
+++ b/dist/Flexbox.js
@@ -25,6 +25,7 @@ var Flexbox = function Flexbox(props) {
   var alignItems = props.alignItems;
   var alignSelf = props.alignSelf;
   var children = props.children;
+  var display = props.display;
   var element = props.element;
   var flex = props.flex;
   var flexBasis = props.flexBasis;
@@ -33,7 +34,6 @@ var Flexbox = function Flexbox(props) {
   var flexShrink = props.flexShrink;
   var flexWrap = props.flexWrap;
   var height = props.height;
-  var inline = props.inline;
   var justifyContent = props.justifyContent;
   var margin = props.margin;
   var marginBottom = props.marginBottom;
@@ -53,9 +53,7 @@ var Flexbox = function Flexbox(props) {
   var style = props.style;
   var width = props.width;
 
-  var other = _objectWithoutProperties(props, ['alignContent', 'alignItems', 'alignSelf', 'children', 'element', 'flex', 'flexBasis', 'flexDirection', 'flexGrow', 'flexShrink', 'flexWrap', 'height', 'inline', 'justifyContent', 'margin', 'marginBottom', 'marginLeft', 'marginRight', 'marginTop', 'maxHeight', 'maxWidth', 'minHeight', 'minWidth', 'order', 'padding', 'paddingBottom', 'paddingLeft', 'paddingRight', 'paddingTop', 'style', 'width']);
-
-  var display = inline ? 'inline-flex' : 'flex';
+  var other = _objectWithoutProperties(props, ['alignContent', 'alignItems', 'alignSelf', 'children', 'display', 'element', 'flex', 'flexBasis', 'flexDirection', 'flexGrow', 'flexShrink', 'flexWrap', 'height', 'justifyContent', 'margin', 'marginBottom', 'marginLeft', 'marginRight', 'marginTop', 'maxHeight', 'maxWidth', 'minHeight', 'minWidth', 'order', 'padding', 'paddingBottom', 'paddingLeft', 'paddingRight', 'paddingTop', 'style', 'width']);
 
   var styles = prefixer.prefix(_extends({
     alignContent: alignContent,
@@ -94,20 +92,21 @@ var Flexbox = function Flexbox(props) {
 };
 
 Flexbox.propTypes = {
-  alignContent: _react.PropTypes.oneOf(['flex-start', 'flex-end', 'center', 'space-between', 'space-around', 'stretch']),
-  alignItems: _react.PropTypes.oneOf(['flex-start', 'flex-end', 'center', 'baseline', 'stretch']),
-  children: _react2.default.PropTypes.node,
+  alignContent: _react.PropTypes.oneOf(['center', 'flex-end', 'flex-start', 'space-around', 'space-between', 'stretch']),
+  alignItems: _react.PropTypes.oneOf(['baseline', 'center', 'flex-end', 'flex-start', 'stretch']),
+  alignSelf: _react.PropTypes.oneOf(['baseline', 'center', 'flex-end', 'flex-start', 'stretch']),
+  children: _react.PropTypes.node,
+  display: _react.PropTypes.oneOf(['flex', 'inline-flex']),
   element: _react.PropTypes.oneOf(['article', 'aside', 'div', 'footer', 'header', 'nav', 'section']),
   flex: _react.PropTypes.string,
   flexBasis: _react.PropTypes.string,
-  flexDirection: _react.PropTypes.oneOf(['row', 'row-reverse', 'column', 'column-reverse']),
+  flexDirection: _react.PropTypes.oneOf(['column-reverse', 'column', 'row-reverse', 'row']),
   flexGrow: _react.PropTypes.number,
   flexShrink: _react.PropTypes.number,
-  alignSelf: _react.PropTypes.oneOf(['flex-start', 'flex-end', 'center', 'baseline', 'stretch']),
-  flexWrap: _react.PropTypes.oneOf(['nowrap', 'wrap', 'wrap-reverse']),
+  flexWrap: _react.PropTypes.oneOf(['nowrap', 'wrap-reverse', 'wrap']),
   height: _react.PropTypes.string,
   inline: _react.PropTypes.bool,
-  justifyContent: _react.PropTypes.oneOf(['flex-start', 'flex-end', 'center', 'space-between', 'space-around']),
+  justifyContent: _react.PropTypes.oneOf(['center', 'flex-end', 'flex-start', 'space-around', 'space-between']),
   margin: _react.PropTypes.string,
   marginBottom: _react.PropTypes.string,
   marginLeft: _react.PropTypes.string,
@@ -128,6 +127,7 @@ Flexbox.propTypes = {
 };
 
 Flexbox.defaultProps = {
+  display: 'flex',
   element: 'div'
 };
 

--- a/src/Flexbox.jsx
+++ b/src/Flexbox.jsx
@@ -9,6 +9,7 @@ const Flexbox = (props) => {
     alignItems,
     alignSelf,
     children,
+    display,
     element,
     flex,
     flexBasis,
@@ -17,7 +18,6 @@ const Flexbox = (props) => {
     flexShrink,
     flexWrap,
     height,
-    inline,
     justifyContent,
     margin,
     marginBottom,
@@ -38,8 +38,6 @@ const Flexbox = (props) => {
     width,
     ...other,
   } = props;
-
-  const display = inline ? 'inline-flex' : 'flex';
 
   const styles = prefixer.prefix({
     alignContent,
@@ -81,21 +79,32 @@ const Flexbox = (props) => {
 
 Flexbox.propTypes = {
   alignContent: PropTypes.oneOf([
-    'flex-start',
-    'flex-end',
     'center',
-    'space-between',
+    'flex-end',
+    'flex-start',
     'space-around',
+    'space-between',
     'stretch',
   ]),
   alignItems: PropTypes.oneOf([
-    'flex-start',
-    'flex-end',
-    'center',
     'baseline',
+    'center',
+    'flex-end',
+    'flex-start',
     'stretch',
   ]),
-  children: React.PropTypes.node,
+  alignSelf: PropTypes.oneOf([
+    'baseline',
+    'center',
+    'flex-end',
+    'flex-start',
+    'stretch',
+  ]),
+  children: PropTypes.node,
+  display: PropTypes.oneOf([
+    'flex',
+    'inline-flex',
+  ]),
   element: PropTypes.oneOf([
     'article',
     'aside',
@@ -108,33 +117,26 @@ Flexbox.propTypes = {
   flex: PropTypes.string,
   flexBasis: PropTypes.string,
   flexDirection: PropTypes.oneOf([
-    'row',
-    'row-reverse',
-    'column',
     'column-reverse',
+    'column',
+    'row-reverse',
+    'row',
   ]),
   flexGrow: PropTypes.number,
   flexShrink: PropTypes.number,
-  alignSelf: PropTypes.oneOf([
-    'flex-start',
-    'flex-end',
-    'center',
-    'baseline',
-    'stretch',
-  ]),
   flexWrap: PropTypes.oneOf([
     'nowrap',
-    'wrap',
     'wrap-reverse',
+    'wrap',
   ]),
   height: PropTypes.string,
   inline: PropTypes.bool,
   justifyContent: PropTypes.oneOf([
-    'flex-start',
-    'flex-end',
     'center',
-    'space-between',
+    'flex-end',
+    'flex-start',
     'space-around',
+    'space-between',
   ]),
   margin: PropTypes.string,
   marginBottom: PropTypes.string,
@@ -156,6 +158,7 @@ Flexbox.propTypes = {
 };
 
 Flexbox.defaultProps = {
+  display: 'flex',
   element: 'div',
 };
 


### PR DESCRIPTION
This fixes #8.
- [x] Replace `inline` with `display`, which can be one of `'flex'` (default) or `'inline-flex'`.
- [x] Fix propTypes ordering (alphabetical order was broken).
- [x] Update distributable.
