### PR TITLE
Move typescript deps as opt deps and new dists

### DIFF
--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -1,0 +1,63 @@
+// TypeScript definitions for flexbox-react
+// Project: https://github.com/nachoaIvarez/flexbox-react
+// Definitions by: Nicholas Gonzalez <https://github.com/nicholasgonzalezsc>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+import * as React from 'react';
+
+export as namespace FlexboxReact;
+export = FlexboxReact;
+
+declare namespace FlexboxReact {
+    type AlignContent = 'center' | 'flex-end' | 'flex-start' | 'space-around' | 'space-between' | 'stretch';
+
+    type AlignItems = 'baseline' | 'center' | 'flex-end' | 'flex-start' | 'stretch';
+
+    type Elements = 'article' | 'aside' | 'div' | 'figure' | 'footer' | 'header' | 'main' | 'nav' | 'section';
+
+    type FlexDisplays = 'flex' | 'inline-flex';
+
+    type FlexDirections = 'column-reverse' | 'column' | 'row-reverse' | 'row';
+
+    type FlexWraps = 'nowrap' | 'wrap-reverse' | 'wrap';
+
+    type JustifyContent = 'center' | 'flex-end' | 'flex-start' | 'space-around' | 'space-between';
+
+    // <Flexbox />
+    interface FlexboxProps {
+        alignContent?: AlignContent;
+        alignItems?: AlignItems;
+        alignSelf?: AlignItems;
+        children?: React.ReactNode;
+        display?: FlexDisplays;
+        element?: Elements;
+        flex?: string;
+        flexBasis?: string;
+        flexDirection?: FlexDirections;
+        flexGrow?: number;
+        flexShrink?: number;
+        flexWrap?: FlexWraps;
+        height?: string;
+        inline?: boolean;
+        justifyContent?: JustifyContent;
+        margin?: string;
+        marginBottom?: string;
+        marginLeft?: string;
+        marginRight?: string;
+        marginTop?: string;
+        maxHeight?: string;
+        maxWidth?: string;
+        minHeight?: string;
+        minWidth?: string;
+        order?: number;
+        padding?: string;
+        paddingBottom?: string;
+        paddingLeft?: string;
+        paddingRight?: string;
+        paddingTop?: string;
+        style?: Object;
+        width?: string;
+    }
+
+    export default class Flexbox extends React.Component<FlexboxProps, {}> {}
+}

--- a/package.json
+++ b/package.json
@@ -15,10 +15,6 @@
     "prebuild": "npm run check -s && npm run clean -s",
     "build": "babel --optional runtime src -d dist --copy-files",
     "prepublish": "npm run build",
-    "deploy": "git pull --rebase origin master && git push origin master",
-    "patch": "npm version patch && npm publish",
-    "minor": "npm version minor && npm publish",
-    "major": "npm version major && npm publish",
     "postpublish": "git push origin master --follow-tags"
   },
   "repository": {
@@ -36,33 +32,35 @@
     "url": "https://github.com/nachoaIvarez/flexbox-react/issues"
   },
   "homepage": "https://github.com/nachoaIvarez/flexbox-react#readme",
+  "optionalDependencies": {
+    "@types/react": "^15.0.0",
+    "@types/react-dom": "^0.14.20"
+  },
   "peerDependencies": {
     "react": "*",
     "react-dom": "*"
   },
   "devDependencies": {
-    "babel-cli": "^6.16.0",
-    "babel-core": "^6.17.0",
-    "babel-eslint": "^7.0.0",
-    "babel-preset-es2015": "^6.16.0",
+    "babel-cli": "^6.18.0",
+    "babel-core": "^6.21.0",
+    "babel-eslint": "^7.1.1",
+    "babel-preset-es2015": "^6.18.0",
     "babel-preset-react": "^6.16.0",
     "babel-preset-stage-0": "^6.16.0",
-    "dependency-check": "^2.6.0",
-    "eslint": "^3.8.0",
-    "eslint-config-airbnb": "^12.0.0",
-    "eslint-plugin-import": "^2.0.1",
-    "eslint-plugin-jsx-a11y": "^2.2.3",
-    "eslint-plugin-react": "^6.4.1",
-    "react": "^15.4.0",
-    "react-dom": "^15.4.0",
+    "dependency-check": "^2.7.0",
+    "eslint": "^3.13.1",
+    "eslint-config-airbnb": "^14.0.0",
+    "eslint-plugin-import": "^2.2.0",
+    "eslint-plugin-jsx-a11y": "^3.0.2",
+    "eslint-plugin-react": "^6.9.0",
+    "react": "^15.4.2",
+    "react-dom": "^15.4.2",
     "rimraf": "^2.5.4",
-    "typescript": "^2.0.10",
+    "typescript": "^2.1.5",
     "watch": "^1.0.1"
   },
   "dependencies": {
-    "@types/react": "^0.14.48",
-    "@types/react-dom": "^0.14.18",
-    "inline-style-prefixer": "^2.0.4",
+    "inline-style-prefixer": "^2.0.5",
     "lodash.pickby": "^4.6.0"
   }
 }


### PR DESCRIPTION
This solves #19. Also, removes publishing scripts in favor of local `np`.