### PR TITLE
Fixed styled component recreation on each render (#26)

### DIFF
--- a/src/Flexbox.jsx
+++ b/src/Flexbox.jsx
@@ -3,8 +3,8 @@ import styled from 'styled-components';
 
 const { string, oneOf, node, number, bool, object } = PropTypes;
 
-const Flexbox = (props) => {
-  const {
+const Flexbox = styled(
+  ({
     alignContent,
     alignItems,
     alignSelf,
@@ -35,42 +35,40 @@ const Flexbox = (props) => {
     paddingRight,
     paddingTop,
     width,
-    ...otherProps
-  } = props;
-
-  const StyledComponent = styled(element)`
-    ${alignContent ? `align-content: ${alignContent};` : ''}
-    ${alignItems ? `align-items: ${alignItems};` : ''}
-    ${alignSelf ? `align-self: ${alignSelf};` : ''}
-    ${display ? `display: ${display};` : ''}
-    ${flex ? `flex: ${flex};` : ''}
-    ${flexBasis ? `flex-basis: ${flexBasis};` : ''}
-    ${flexDirection ? `flex-direction: ${flexDirection};` : ''}
-    ${flexGrow ? `flex-grow: ${flexGrow};` : ''}
-    ${flexShrink ? `flex-shrink: ${flexShrink};` : ''}
-    ${flexWrap ? `flex-wrap: ${flexWrap};` : ''}
-    ${height ? `height: ${height};` : ''}
-    ${justifyContent ? `justify-content: ${justifyContent};` : ''}
-    ${margin ? `margin: ${margin};` : ''}
-    ${marginBottom ? `margin-bottom: ${marginBottom};` : ''}
-    ${marginLeft ? `margin-left: ${marginLeft};` : ''}
-    ${marginRight ? `margin-right: ${marginRight};` : ''}
-    ${marginTop ? `margin-top: ${marginTop};` : ''}
-    ${maxHeight ? `max-height: ${maxHeight};` : ''}
-    ${maxWidth ? `max-width: ${maxWidth};` : ''}
-    ${minHeight ? `min-height: ${minHeight};` : ''}
-    ${minWidth ? `min-width: ${minWidth};` : ''}
-    ${order ? `order: ${order};` : ''}
-    ${padding ? `padding: ${padding};` : ''}
-    ${paddingBottom ? `padding-bottom: ${paddingBottom};` : ''}
-    ${paddingLeft ? `padding-left: ${paddingLeft};` : ''}
-    ${paddingRight ? `padding-right: ${paddingRight};` : ''}
-    ${paddingTop ? `padding-top: ${paddingTop};` : ''}
-    ${width ? `width: ${width};` : ''}
-  `;
-
-  return React.createElement(StyledComponent, otherProps, children);
-};
+    ...props
+  }) => {
+    return React.createElement(element, props, children);
+  }
+)`
+  ${props => props.alignContent ? `align-content: ${props.alignContent};` : ''}
+  ${props => props.alignSelf ? `align-self: ${props.alignSelf};` : ''}
+  ${props => props.alignItems ? `align-items: ${props.alignItems};` : ''}
+  ${props => props.display ? `display: ${props.display};` : ''}
+  ${props => props.flex ? `flex: ${props.flex};` : ''}
+  ${props => props.flexBasis ? `flex-basis: ${props.flexBasis};` : ''}
+  ${props => props.flexDirection ? `flex-direction: ${props.flexDirection};` : ''}
+  ${props => props.flexGrow ? `flex-grow: ${props.flexGrow};` : ''}
+  ${props => props.flexShrink ? `flex-shrink: ${props.flexShrink};` : ''}
+  ${props => props.flexWrap ? `flex-wrap: ${props.flexWrap};` : ''}
+  ${props => props.height ? `height: ${props.height};` : ''}
+  ${props => props.justifyContent ? `justify-content: ${props.justifyContent};` : ''}
+  ${props => props.margin ? `margin: ${props.margin};` : ''}
+  ${props => props.marginBottom ? `margin-bottom: ${props.marginBottom};` : ''}
+  ${props => props.marginLeft ? `margin-left: ${props.marginLeft};` : ''}
+  ${props => props.marginRight ? `margin-right: ${props.marginRight};` : ''}
+  ${props => props.marginTop ? `margin-top: ${props.marginTop};` : ''}
+  ${props => props.maxHeight ? `max-height: ${props.maxHeight};` : ''}
+  ${props => props.maxWidth ? `max-width: ${props.maxWidth};` : ''}
+  ${props => props.minHeight ? `min-height: ${props.minHeight};` : ''}
+  ${props => props.minWidth ? `min-width: ${props.minWidth};` : ''}
+  ${props => props.order ? `order: ${props.order};` : ''}
+  ${props => props.padding ? `padding: ${props.padding};` : ''}
+  ${props => props.paddingBottom ? `padding-bottom: ${props.paddingBottom};` : ''}
+  ${props => props.paddingLeft ? `padding-left: ${props.paddingLeft};` : ''}
+  ${props => props.paddingRight ? `padding-right: ${props.paddingRight};` : ''}
+  ${props => props.paddingTop ? `padding-top: ${props.paddingTop};` : ''}
+  ${props => props.width ? `width: ${props.width};` : ''}
+`;
 
 Flexbox.propTypes = {
   alignContent: oneOf([

--- a/src/__tests__/__snapshots__/Flexbox.react-test.jsx.snap
+++ b/src/__tests__/__snapshots__/Flexbox.react-test.jsx.snap
@@ -1,14 +1,14 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Renders <Flexbox /> component with layout helpers (height, width, margin, padding, etc) 1`] = `
-".gyZqoD {
+".cmOkcp {
   display:-webkit-box;
   display:-moz-box;
   display:-ms-flexbox;
   display:-webkit-flex;
   display:flex;
 }
-.gaFQwb {
+.jwcsUI {
   align-items:center;
   -webkit-box-align:center;
   -ms-flex-align:center;
@@ -35,7 +35,7 @@ exports[`Renders <Flexbox /> component with layout helpers (height, width, margi
   -ms-flex-pack:center;
   -webkit-justify-content:center;
 }
-.idrnwy {
+.YQCAm {
   display:-webkit-box;
   display:-moz-box;
   display:-ms-flexbox;
@@ -55,19 +55,19 @@ exports[`Renders <Flexbox /> component with layout helpers (height, width, margi
 
 exports[`Renders <Flexbox /> component with layout helpers (height, width, margin, padding, etc) 2`] = `
 <div
-  className="idrnwy"
+  className="YQCAm"
 />
 `;
 
 exports[`Renders <Flexbox /> component with several flexbox props 1`] = `
-".gyZqoD {
+".cmOkcp {
   display:-webkit-box;
   display:-moz-box;
   display:-ms-flexbox;
   display:-webkit-flex;
   display:flex;
 }
-.gaFQwb {
+.jwcsUI {
   align-items:center;
   -webkit-box-align:center;
   -ms-flex-align:center;
@@ -99,19 +99,19 @@ exports[`Renders <Flexbox /> component with several flexbox props 1`] = `
 
 exports[`Renders <Flexbox /> component with several flexbox props 2`] = `
 <div
-  className="gaFQwb"
+  className="jwcsUI"
 />
 `;
 
 exports[`Renders <Flexbox /> with extra props, outside expected/defined ones (like event handlers or className) 1`] = `
-".gyZqoD {
+".cmOkcp {
   display:-webkit-box;
   display:-moz-box;
   display:-ms-flexbox;
   display:-webkit-flex;
   display:flex;
 }
-.gaFQwb {
+.jwcsUI {
   align-items:center;
   -webkit-box-align:center;
   -ms-flex-align:center;
@@ -138,7 +138,7 @@ exports[`Renders <Flexbox /> with extra props, outside expected/defined ones (li
   -ms-flex-pack:center;
   -webkit-justify-content:center;
 }
-.idrnwy {
+.YQCAm {
   display:-webkit-box;
   display:-moz-box;
   display:-ms-flexbox;
@@ -158,21 +158,21 @@ exports[`Renders <Flexbox /> with extra props, outside expected/defined ones (li
 
 exports[`Renders <Flexbox /> with extra props, outside expected/defined ones (like event handlers or className) 2`] = `
 <div
-  className="test-class gyZqoD"
+  className="test-class cmOkcp"
   id="test-id"
   onClick={[Function]}
 />
 `;
 
 exports[`Renders <Flexbox /> with inline styles that can overwrite flexbox-react related props too 1`] = `
-".gyZqoD {
+".cmOkcp {
   display:-webkit-box;
   display:-moz-box;
   display:-ms-flexbox;
   display:-webkit-flex;
   display:flex;
 }
-.gaFQwb {
+.jwcsUI {
   align-items:center;
   -webkit-box-align:center;
   -ms-flex-align:center;
@@ -199,7 +199,7 @@ exports[`Renders <Flexbox /> with inline styles that can overwrite flexbox-react
   -ms-flex-pack:center;
   -webkit-justify-content:center;
 }
-.idrnwy {
+.YQCAm {
   display:-webkit-box;
   display:-moz-box;
   display:-ms-flexbox;
@@ -219,7 +219,7 @@ exports[`Renders <Flexbox /> with inline styles that can overwrite flexbox-react
 
 exports[`Renders <Flexbox /> with inline styles that can overwrite flexbox-react related props too 2`] = `
 <div
-  className="gyZqoD"
+  className="cmOkcp"
   style={
     Object {
       "backgroundColor": "red",
@@ -230,7 +230,7 @@ exports[`Renders <Flexbox /> with inline styles that can overwrite flexbox-react
 `;
 
 exports[`Renders custom element (header) <Flexbox /> component 1`] = `
-".gyZqoD {
+".cmOkcp {
   display:-webkit-box;
   display:-moz-box;
   display:-ms-flexbox;
@@ -242,12 +242,12 @@ exports[`Renders custom element (header) <Flexbox /> component 1`] = `
 
 exports[`Renders custom element (header) <Flexbox /> component 2`] = `
 <header
-  className="gyZqoD"
+  className="cmOkcp"
 />
 `;
 
 exports[`Renders minimal <Flexbox /> component 1`] = `
-".gyZqoD {
+".cmOkcp {
   display:-webkit-box;
   display:-moz-box;
   display:-ms-flexbox;
@@ -259,6 +259,6 @@ exports[`Renders minimal <Flexbox /> component 1`] = `
 
 exports[`Renders minimal <Flexbox /> component 2`] = `
 <div
-  className="gyZqoD"
+  className="cmOkcp"
 />
 `;


### PR DESCRIPTION
This should fix the problems described in #26. 
Snapshot test output seems identical except for newly generated classnames. 
I thought of adding an extra test that ensures that component isn't regenerated on each render but I don't have enough experience with Jest to be able to contribute that yet :)