### PR TITLE
- Added "className" to typings for typescript

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text eol=lf

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -29,6 +29,7 @@ declare namespace FlexboxReact {
         alignItems?: AlignItems;
         alignSelf?: AlignItems;
         children?: React.ReactNode;
+		className?: string;
         display?: FlexDisplays;
         element?: Elements;
         flex?: string;

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -29,7 +29,7 @@ declare namespace FlexboxReact {
         alignItems?: AlignItems;
         alignSelf?: AlignItems;
         children?: React.ReactNode;
-		className?: string;
+        className?: string;
         display?: FlexDisplays;
         element?: Elements;
         flex?: string;


### PR DESCRIPTION
- Added .gitignore file to explicitly checkout in lf text mode which is required by the linter (failed on Windows otherwise)

#27 