### PR TITLE
Fix PropTypes deprecation warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ or any other arbitrarily named and _spec_&hairsp;ed props to layout your apps.
 `flexbox-react` is agnostic of which post/pre css build flow you have, it works out of the box. It's agnostic to it. You could have all your styling on css files. Or all inlined. This sits just in the middle. It might be a good idea to see your components and know how they are laid out without jumping between css files or arbitrary, layout-exclusive components specifications.
 
 ## How
-No hardcoded, bloated, unnecesary vendor prefixes, by
+No hardcoded, bloated, unnecessary vendor prefixes, by
 <a href="http://caniuse.com"> caniuse</a>. Just those your browser needs, based
 on your `userAgent`.
 
@@ -56,19 +56,16 @@ component.
 
 ```sh
 yarn add flexbox-react
-```
-or
-```
-npm i --save flexbox-react
+# or
+npm install --save flexbox-react
 ```
 
 ## Usage
 ```js
 import Flexbox from 'flexbox-react';
 
-//...
+// ...
 <Flexbox flexDirection="column" minHeight="100vh">
-
   <Flexbox element="header" height="60px">
     Header
   </Flexbox>
@@ -80,12 +77,11 @@ import Flexbox from 'flexbox-react';
   <Flexbox element="footer" height="60px">
     Footer
   </Flexbox>
-
 </Flexbox>
 ```
 *Sticky footer!*
 
-As you can see, there's some extra props as _layout_&hairsp;ing helpers. Those are `height`, `minHeight`, `maxHeight`, `width`, `minWidth`, `maxWidth`, `padding`, `paddingTop`, `paddingRight`, `paddingBottom`, `paddingLeft`, `margin`, `marginTop`, `marginRight`, `marginBottom`, and `marginLeft`. The idea of `flexbox-react` is to be a complete solution to build layouts. Since, well, flexbox it is a complete solution to build layouts. It's all about the sugar. Feel free to create an issue or submit a PR if you think there's room for improvement here!
+As you can see, there're some extra props as _layout_&hairsp;ing helpers. Those are `height`, `minHeight`, `maxHeight`, `width`, `minWidth`, `maxWidth`, `padding`, `paddingTop`, `paddingRight`, `paddingBottom`, `paddingLeft`, `margin`, `marginTop`, `marginRight`, `marginBottom`, and `marginLeft`. The idea of `flexbox-react` is to be a complete solution to build layouts. Since, well, flexbox is a complete solution to build layouts. It's all about the sugar. Feel free to create an issue or submit a PR if you think there's room for improvement here!
 
 ### Semantic HTML tags
 
@@ -107,8 +103,7 @@ which will render to this:
 
 ## Props
 Take a look at
-[Flexbox PropTypes](https://github.com/nachoaIvarez/flexbox-react/blob/master/src/Flexbox.jsx#L82-L157). No mysteries. As said, you just need to know actual flexbox properties not any propietary syntax for them, if you're not familiar with flexbox, here is a
-[good starting point](https://css-tricks.com/snippets/css/a-guide-to-flexbox/).
+[Flexbox PropTypes](https://github.com/nachoaIvarez/flexbox-react/blob/master/src/Flexbox.jsx#L68-L141). No mysteries. As said, you just need to know actual flexbox properties not any proprietary syntax for them. If you're not familiar with flexbox, [this is a good starting point](https://css-tricks.com/snippets/css/a-guide-to-flexbox/).
 
 If TypeScript is your cup of tea, check the [type definitions](https://github.com/nachoaIvarez/flexbox-react/blob/master/src/index.d.ts), we support them too.
 

--- a/package.json
+++ b/package.json
@@ -34,10 +34,11 @@
   },
   "homepage": "https://github.com/nachoaIvarez/flexbox-react#readme",
   "optionalDependencies": {
-    "@types/react": "^15.0.0",
-    "@types/react-dom": "^0.14.20"
+    "@types/react": "^15.0.21",
+    "@types/react-dom": "^0.14.23"
   },
   "peerDependencies": {
+    "prop-types": "*",
     "react": "*",
     "react-dom": "*"
   },
@@ -56,15 +57,16 @@
     "eslint-plugin-jsx-a11y": "^3.0.2",
     "eslint-plugin-react": "^6.9.0",
     "jest": "^19.0.2",
-    "react": "^15.4.2",
-    "react-dom": "^15.4.2",
-    "react-test-renderer": "^15.4.2",
+    "prop-types": "^15.5.8",
+    "react": "^15.5.4",
+    "react-dom": "^15.5.4",
+    "react-test-renderer": "^15.5.4",
     "rimraf": "^2.5.4",
     "typescript": "^2.1.5",
     "watch": "^1.0.1"
   },
   "dependencies": {
-    "styled-components": "^1.4.4"
+    "styled-components": "^1.4.5"
   },
   "jest": {
     "testEnvironment": "jsdom"

--- a/src/Flexbox.jsx
+++ b/src/Flexbox.jsx
@@ -1,7 +1,6 @@
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React from 'react';
 import styled from 'styled-components';
-
-const { string, oneOf, node, number, bool, object } = PropTypes;
 
 const Flexbox = styled(({
   alignContent,
@@ -67,7 +66,7 @@ const Flexbox = styled(({
 `;
 
 Flexbox.propTypes = {
-  alignContent: oneOf([
+  alignContent: PropTypes.oneOf([
     'center',
     'flex-end',
     'flex-start',
@@ -75,11 +74,23 @@ Flexbox.propTypes = {
     'space-between',
     'stretch',
   ]),
-  alignItems: oneOf(['baseline', 'center', 'flex-end', 'flex-start', 'stretch']),
-  alignSelf: oneOf(['baseline', 'center', 'flex-end', 'flex-start', 'stretch']),
-  children: node,
-  display: oneOf(['flex', 'inline-flex']),
-  element: oneOf([
+  alignItems: PropTypes.oneOf([
+    'baseline',
+    'center',
+    'flex-end',
+    'flex-start',
+    'stretch',
+  ]),
+  alignSelf: PropTypes.oneOf([
+    'baseline',
+    'center',
+    'flex-end',
+    'flex-start',
+    'stretch',
+  ]),
+  children: PropTypes.node,
+  display: PropTypes.oneOf(['flex', 'inline-flex']),
+  element: PropTypes.oneOf([
     'article',
     'aside',
     'div',
@@ -90,32 +101,43 @@ Flexbox.propTypes = {
     'nav',
     'section',
   ]),
-  flex: string,
-  flexBasis: string,
-  flexDirection: oneOf(['column-reverse', 'column', 'row-reverse', 'row']),
-  flexGrow: number,
-  flexShrink: number,
-  flexWrap: oneOf(['nowrap', 'wrap-reverse', 'wrap']),
-  height: string,
-  inline: bool,
-  justifyContent: oneOf(['center', 'flex-end', 'flex-start', 'space-around', 'space-between']),
-  margin: string,
-  marginBottom: string,
-  marginLeft: string,
-  marginRight: string,
-  marginTop: string,
-  maxHeight: string,
-  maxWidth: string,
-  minHeight: string,
-  minWidth: string,
-  order: number,
-  padding: string,
-  paddingBottom: string,
-  paddingLeft: string,
-  paddingRight: string,
-  paddingTop: string,
-  style: object,
-  width: string,
+  flex: PropTypes.string,
+  flexBasis: PropTypes.string,
+  flexDirection: PropTypes.oneOf([
+    'column-reverse',
+    'column',
+    'row-reverse',
+    'row',
+  ]),
+  flexGrow: PropTypes.number,
+  flexShrink: PropTypes.number,
+  flexWrap: PropTypes.oneOf(['nowrap', 'wrap-reverse', 'wrap']),
+  height: PropTypes.string,
+  inline: PropTypes.bool,
+  justifyContent: PropTypes.oneOf([
+    'center',
+    'flex-end',
+    'flex-start',
+    'space-around',
+    'space-between',
+  ]),
+  margin: PropTypes.string,
+  marginBottom: PropTypes.string,
+  marginLeft: PropTypes.string,
+  marginRight: PropTypes.string,
+  marginTop: PropTypes.string,
+  maxHeight: PropTypes.string,
+  maxWidth: PropTypes.string,
+  minHeight: PropTypes.string,
+  minWidth: PropTypes.string,
+  order: PropTypes.number,
+  padding: PropTypes.string,
+  paddingBottom: PropTypes.string,
+  paddingLeft: PropTypes.string,
+  paddingRight: PropTypes.string,
+  paddingTop: PropTypes.string,
+  style: PropTypes.object,
+  width: PropTypes.string,
 };
 
 Flexbox.defaultProps = {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,15 +2,15 @@
 # yarn lockfile v1
 
 
-"@types/react-dom@^0.14.20":
-  version "0.14.20"
-  resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-0.14.20.tgz#6e30d66148e78b29ef593fa91ba30d0175190604"
+"@types/react-dom@^0.14.23":
+  version "0.14.23"
+  resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-0.14.23.tgz#cecfcfad754b4c2765fe5d29b81b301889ad6c2e"
   dependencies:
     "@types/react" "*"
 
-"@types/react@*", "@types/react@^15.0.0":
-  version "15.0.0"
-  resolved "https://registry.yarnpkg.com/@types/react/-/react-15.0.0.tgz#33eb3438130614f25c07c09e46ebec5a8d45b3b0"
+"@types/react@*", "@types/react@^15.0.21":
+  version "15.0.21"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-15.0.21.tgz#29d849427237c1463abfb7b370755ee3e5b5b375"
 
 abab@^1.0.3:
   version "1.0.3"
@@ -1657,9 +1657,9 @@ fb-watchman@^2.0.0:
   dependencies:
     bser "^2.0.0"
 
-fbjs@^0.8.1, fbjs@^0.8.4, fbjs@^0.8.5, fbjs@^0.8.7, fbjs@^0.8.8:
-  version "0.8.8"
-  resolved "https://registry.yarnpkg.com/fbjs/-/fbjs-0.8.8.tgz#02f1b6e0ea0d46c24e0b51a2d24df069563a5ad6"
+fbjs@^0.8.5, fbjs@^0.8.7, fbjs@^0.8.9:
+  version "0.8.12"
+  resolved "https://registry.yarnpkg.com/fbjs/-/fbjs-0.8.12.tgz#10b5d92f76d45575fd63a217d4ea02bea2f8ed04"
   dependencies:
     core-js "^1.0.0"
     isomorphic-fetch "^2.1.1"
@@ -1822,14 +1822,6 @@ getpass@^0.1.1:
   dependencies:
     assert-plus "^1.0.0"
 
-glamor@^2.20.12:
-  version "2.20.24"
-  resolved "https://registry.yarnpkg.com/glamor/-/glamor-2.20.24.tgz#a299af2eec687322634ba38e4a0854d8743d2041"
-  dependencies:
-    babel-runtime "^6.18.0"
-    fbjs "^0.8.8"
-    object-assign "^4.1.0"
-
 glob-base@^0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/glob-base/-/glob-base-0.3.0.tgz#dbb164f6221b1c0b1ccf82aea328b497df0ea3c4"
@@ -1982,13 +1974,9 @@ hyphenate-style-name@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/hyphenate-style-name/-/hyphenate-style-name-1.0.2.tgz#31160a36930adaf1fc04c6074f7eb41465d4ec4b"
 
-iconv-lite@0.4.13:
+iconv-lite@0.4.13, iconv-lite@~0.4.13:
   version "0.4.13"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.13.tgz#1f88aba4ab0b1508e8312acc39345f36e992e2f2"
-
-iconv-lite@~0.4.13:
-  version "0.4.15"
-  resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.15.tgz#fe265a218ac6a57cfe854927e9d04c19825eddeb"
 
 ieee754@^1.1.4:
   version "1.1.8"
@@ -3049,6 +3037,12 @@ promise@^7.1.1:
   dependencies:
     asap "~2.0.3"
 
+prop-types@^15.5.4, prop-types@^15.5.7, prop-types@^15.5.8, prop-types@~15.5.7:
+  version "15.5.8"
+  resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.5.8.tgz#6b7b2e141083be38c8595aa51fc55775c7199394"
+  dependencies:
+    fbjs "^0.8.9"
+
 prr@~0.0.0:
   version "0.0.0"
   resolved "https://registry.yarnpkg.com/prr/-/prr-0.0.0.tgz#1a84b85908325501411853d0081ee3fa86e2926a"
@@ -3088,28 +3082,30 @@ rc@~1.1.6:
     minimist "^1.2.0"
     strip-json-comments "~1.0.4"
 
-react-dom@^15.4.2:
-  version "15.4.2"
-  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-15.4.2.tgz#015363f05b0a1fd52ae9efdd3a0060d90695208f"
+react-dom@^15.5.4:
+  version "15.5.4"
+  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-15.5.4.tgz#ba0c28786fd52ed7e4f2135fe0288d462aef93da"
   dependencies:
-    fbjs "^0.8.1"
+    fbjs "^0.8.9"
     loose-envify "^1.1.0"
     object-assign "^4.1.0"
+    prop-types "~15.5.7"
 
-react-test-renderer@^15.4.2:
-  version "15.4.2"
-  resolved "https://registry.yarnpkg.com/react-test-renderer/-/react-test-renderer-15.4.2.tgz#27e1dff5d26d0e830f99614c487622bc831416f3"
+react-test-renderer@^15.5.4:
+  version "15.5.4"
+  resolved "https://registry.yarnpkg.com/react-test-renderer/-/react-test-renderer-15.5.4.tgz#d4ebb23f613d685ea8f5390109c2d20fbf7c83bc"
   dependencies:
-    fbjs "^0.8.4"
+    fbjs "^0.8.9"
     object-assign "^4.1.0"
 
-react@^15.4.2:
-  version "15.4.2"
-  resolved "https://registry.yarnpkg.com/react/-/react-15.4.2.tgz#41f7991b26185392ba9bae96c8889e7e018397ef"
+react@^15.5.4:
+  version "15.5.4"
+  resolved "https://registry.yarnpkg.com/react/-/react-15.5.4.tgz#fa83eb01506ab237cdc1c8c3b1cea8de012bf047"
   dependencies:
-    fbjs "^0.8.4"
+    fbjs "^0.8.9"
     loose-envify "^1.1.0"
     object-assign "^4.1.0"
+    prop-types "^15.5.7"
 
 read-package-json@^2.0.4:
   version "2.0.4"
@@ -3493,17 +3489,17 @@ strip-json-comments@~2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-2.0.1.tgz#3c531942e908c2697c0ec344858c286c7ca0a60a"
 
-styled-components@^1.4.4:
-  version "1.4.4"
-  resolved "https://registry.yarnpkg.com/styled-components/-/styled-components-1.4.4.tgz#c944de423d8ae2363f2ba4ff8fc26d367e7dfa8f"
+styled-components@^1.4.5:
+  version "1.4.5"
+  resolved "https://registry.yarnpkg.com/styled-components/-/styled-components-1.4.5.tgz#20c52f6355e28c7f20a99c05c6d5108a4858cfba"
   dependencies:
     buffer "^5.0.2"
     css-to-react-native "^1.0.6"
     fbjs "^0.8.7"
-    glamor "^2.20.12"
     inline-style-prefixer "^2.0.5"
     is-function "^1.0.1"
     is-plain-object "^2.0.1"
+    prop-types "^15.5.4"
     supports-color "^3.1.2"
 
 supports-color@^0.2.0:


### PR DESCRIPTION
This is a first step to fix the PropTypes deprecation warning. I updated the related dependencies, and installed the new `prop-types` package, but I'm still not too sure about if it should be a development dependency or not. Right now it's a production dependency, which may not produce an optimal build for those folks using TypeScript, for example.