### PR TITLE
Fixed TypeScript typings so TypeScript 2.5.2 does not complain

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,16 +33,14 @@
     "url": "https://github.com/nachoaIvarez/flexbox-react/issues"
   },
   "homepage": "https://github.com/nachoaIvarez/flexbox-react#readme",
-  "optionalDependencies": {
-    "@types/react": "^15.0.21",
-    "@types/react-dom": "^0.14.23"
-  },
   "peerDependencies": {
     "prop-types": "*",
     "react": "*",
     "react-dom": "*"
   },
   "devDependencies": {
+    "@types/react": "^15.0.21",
+    "@types/react-dom": "^0.14.23",
     "babel-cli": "^6.24.1",
     "babel-core": "^6.24.1",
     "babel-eslint": "^7.2.2",

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -6,7 +6,6 @@
 import * as React from 'react';
 
 export as namespace FlexboxReact;
-export = FlexboxReact;
 
 declare namespace FlexboxReact {
     type AlignContent = 'center' | 'flex-end' | 'flex-start' | 'space-around' | 'space-between' | 'stretch';
@@ -60,5 +59,7 @@ declare namespace FlexboxReact {
         width?: string;
     }
 
-    export default class Flexbox extends React.Component<FlexboxProps, {}> {}
+    export class Flexbox extends React.Component<FlexboxProps, {}> {}
 }
+
+export default FlexboxReact.Flexbox;


### PR DESCRIPTION
TypeScript 2.5.2 complains about the typings because namespaces are not supposed to have default exports (only ES6 modules). This pull request fixes the typings by lifting the default export up to the module level.