### PR TITLE
Add block display option for terminal flex items.

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "clean": "rimraf dist",
     "lint": "eslint src",
     "test": "jest",
-    "check": "yarn run lint -s && yarn run test && dependency-check package.json --entry src",
+    "check": "yarn run lint && yarn run test && dependency-check package.json --entry src",
     "prebuild": "yarn run check -s && yarn run clean -s",
     "build": "babel --optional runtime src -d dist --copy-files --ignore src/__tests__",
     "prepublish": "yarn run build",

--- a/src/Flexbox.jsx
+++ b/src/Flexbox.jsx
@@ -77,7 +77,7 @@ Flexbox.propTypes = {
   alignItems: PropTypes.oneOf(['baseline', 'center', 'flex-end', 'flex-start', 'stretch']),
   alignSelf: PropTypes.oneOf(['baseline', 'center', 'flex-end', 'flex-start', 'stretch']),
   children: PropTypes.node,
-  display: PropTypes.oneOf(['display', 'flex', 'inline-flex']),
+  display: PropTypes.oneOf(['block', 'flex', 'inline-flex']),
   element: PropTypes.oneOf([
     'article',
     'aside',

--- a/src/Flexbox.jsx
+++ b/src/Flexbox.jsx
@@ -77,7 +77,7 @@ Flexbox.propTypes = {
   alignItems: PropTypes.oneOf(['baseline', 'center', 'flex-end', 'flex-start', 'stretch']),
   alignSelf: PropTypes.oneOf(['baseline', 'center', 'flex-end', 'flex-start', 'stretch']),
   children: PropTypes.node,
-  display: PropTypes.oneOf(['flex', 'inline-flex']),
+  display: PropTypes.oneOf(['display', 'flex', 'inline-flex']),
   element: PropTypes.oneOf([
     'article',
     'aside',

--- a/src/__tests__/Flexbox.react-test.jsx
+++ b/src/__tests__/Flexbox.react-test.jsx
@@ -88,3 +88,12 @@ test(
     />,
   ),
 );
+
+test(
+  'Renders <Flexbox /> with flex items with non-flex display',
+  testComponent(
+    <Flexbox>
+      <Flexbox display="block" />
+    </Flexbox>,
+  ),
+);

--- a/src/__tests__/__snapshots__/Flexbox.react-test.jsx.snap
+++ b/src/__tests__/__snapshots__/Flexbox.react-test.jsx.snap
@@ -21,8 +21,9 @@ exports[`Renders <Flexbox /> component with layout helpers (height, width, margi
   -webkit-flex-direction:column;
   -ms-flex-direction:column;
   flex-direction:column;
+  -webkit-box-flex:1;
   -webkit-flex-grow:1;
-  -ms-flex-grow:1;
+  -ms-flex-positive:1;
   flex-grow:1;
   -webkit-flex-wrap:wrap;
   -ms-flex-wrap:wrap;
@@ -76,8 +77,9 @@ exports[`Renders <Flexbox /> component with several flexbox props 1`] = `
   -webkit-flex-direction:column;
   -ms-flex-direction:column;
   flex-direction:column;
+  -webkit-box-flex:1;
   -webkit-flex-grow:1;
-  -ms-flex-grow:1;
+  -ms-flex-positive:1;
   flex-grow:1;
   -webkit-flex-wrap:wrap;
   -ms-flex-wrap:wrap;
@@ -117,8 +119,9 @@ exports[`Renders <Flexbox /> with extra props, outside expected/defined ones (li
   -webkit-flex-direction:column;
   -ms-flex-direction:column;
   flex-direction:column;
+  -webkit-box-flex:1;
   -webkit-flex-grow:1;
-  -ms-flex-grow:1;
+  -ms-flex-positive:1;
   flex-grow:1;
   -webkit-flex-wrap:wrap;
   -ms-flex-wrap:wrap;
@@ -153,6 +156,69 @@ exports[`Renders <Flexbox /> with extra props, outside expected/defined ones (li
 />
 `;
 
+exports[`Renders <Flexbox /> with flex items with non-flex display 1`] = `
+"/*sc-component-id:sc-bdVaJa*/.sc-bdVaJa {
+}
+.cXgeQK {
+  display:-webkit-box;
+  display:-webkit-flex;
+  display:-ms-flexbox;
+  display:flex;
+}
+.DtNwl {
+  -webkit-align-items:center;
+  -webkit-box-align:center;
+  -ms-flex-align:center;
+  align-items:center;
+  display:-webkit-box;
+  display:-webkit-flex;
+  display:-ms-flexbox;
+  display:flex;
+  -webkit-flex-direction:column;
+  -ms-flex-direction:column;
+  flex-direction:column;
+  -webkit-box-flex:1;
+  -webkit-flex-grow:1;
+  -ms-flex-positive:1;
+  flex-grow:1;
+  -webkit-flex-wrap:wrap;
+  -ms-flex-wrap:wrap;
+  flex-wrap:wrap;
+  -webkit-box-pack:center;
+  -webkit-justify-content:center;
+  -ms-flex-pack:center;
+  justify-content:center;
+}
+.eylexG {
+  display:-webkit-box;
+  display:-webkit-flex;
+  display:-ms-flexbox;
+  display:flex;
+  height:100%;
+  margin:66px33px;
+  margin-right:25px;
+  max-width:100vw;
+  min-height:100vh;
+  padding:99px;
+  padding-left:50px;
+  width:100px;
+}
+.dLBgrm {
+  display:block;
+}
+"
+`;
+
+exports[`Renders <Flexbox /> with flex items with non-flex display 2`] = `
+<div
+  className="sc-bdVaJa cXgeQK"
+>
+  <div
+    className="sc-bdVaJa dLBgrm"
+  />
+</div>
+`;
+
 exports[`Renders <Flexbox /> with inline styles that can overwrite flexbox-react related props too 1`] = `
 "/*sc-component-id:sc-bdVaJa*/.sc-bdVaJa {
 }
@@ -174,8 +240,9 @@ exports[`Renders <Flexbox /> with inline styles that can overwrite flexbox-react
   -webkit-flex-direction:column;
   -ms-flex-direction:column;
   flex-direction:column;
+  -webkit-box-flex:1;
   -webkit-flex-grow:1;
-  -ms-flex-grow:1;
+  -ms-flex-positive:1;
   flex-grow:1;
   -webkit-flex-wrap:wrap;
   -ms-flex-wrap:wrap;

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -15,7 +15,7 @@ declare namespace FlexboxReact {
 
     type Elements = 'article' | 'aside' | 'div' | 'figure' | 'footer' | 'header' | 'main' | 'nav' | 'section';
 
-    type FlexDisplays = 'flex' | 'inline-flex';
+    type FlexDisplays = 'display' | 'flex' | 'inline-flex';
 
     type FlexDirections = 'column-reverse' | 'column' | 'row-reverse' | 'row';
 

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -15,7 +15,7 @@ declare namespace FlexboxReact {
 
     type Elements = 'article' | 'aside' | 'div' | 'figure' | 'footer' | 'header' | 'main' | 'nav' | 'section';
 
-    type FlexDisplays = 'display' | 'flex' | 'inline-flex';
+    type FlexDisplays = 'block' | 'flex' | 'inline-flex';
 
     type FlexDirections = 'column-reverse' | 'column' | 'row-reverse' | 'row';
 


### PR DESCRIPTION
Solves this [this issue](https://github.com/nachoaIvarez/flexbox-react/issues/47) by adding a `display: block` option. Rather than building logic in the API that determines whether the `<Flexbox />` instance is a flex container or flex item, we can leave it up to the API consumer to manually set the `display` to whatever they need.